### PR TITLE
more conservative iptables through iptables-persistent

### DIFF
--- a/etc/iptables/rules.v4
+++ b/etc/iptables/rules.v4
@@ -1,0 +1,24 @@
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [1216:88995]
+-A INPUT -i lo -j ACCEPT
+-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+# allow SSH, ICMP, HTTP, and fastd
+-A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
+-A INPUT -p icmp -j ACCEPT
+-A INPUT -p tcp -m tcp --dport 80 -j ACCEPT
+-A INPUT -p tcp -m tcp --dport 1244 -j ACCEPT
+-A INPUT -p udp -m udp --dport 1244 -j ACCEPT
+
+# allow connections from freifunk if they originated here
+-A INPUT -i bat0 -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+COMMIT
+*nat
+:PREROUTING ACCEPT [5937:390086]
+:INPUT ACCEPT [5235:337093]
+:OUTPUT ACCEPT [2619:167605]
+:POSTROUTING ACCEPT [2619:167605]
+COMMIT

--- a/etc/iptables/rules.v4
+++ b/etc/iptables/rules.v4
@@ -12,9 +12,6 @@
 -A INPUT -p tcp -m tcp --dport 1244 -j ACCEPT
 -A INPUT -p udp -m udp --dport 1244 -j ACCEPT
 
-# allow connections from freifunk if they originated here
--A INPUT -i bat0 -m state --state ESTABLISHED,RELATED -j ACCEPT
-
 COMMIT
 *nat
 :PREROUTING ACCEPT [5937:390086]

--- a/etc/iptables/rules.v6
+++ b/etc/iptables/rules.v6
@@ -1,0 +1,34 @@
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [18:932]
+-A INPUT -i lo -j ACCEPT
+-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+# allow SSH, ICMP, and HTTP
+-A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
+-A INPUT -p icmp -j ACCEPT
+-A INPUT -p icmpv6 -j ACCEPT
+-A INPUT -p tcp -m tcp --dport 80 -j ACCEPT
+
+# allow established connections from freifunk
+-A INPUT -i bat0 -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# allow DNS from freifunk
+-A INPUT -i bat0 -p tcp --dport domain -j ACCEPT
+-A INPUT -i bat0 -p udp --dport domain -j ACCEPT
+
+# allow ALFRED from freifunk
+-A INPUT -i bat0 -p udp --dport 16962 -j ACCEPT
+
+# allow NAT64
+-A FORWARD -i bat0 -o nat64 -j ACCEPT
+-A FORWARD -i nat64 -o bat0 -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+COMMIT
+*nat
+:PREROUTING ACCEPT [22:5968]
+:INPUT ACCEPT [22:5968]
+:OUTPUT ACCEPT [1:52]
+:POSTROUTING ACCEPT [1:52]
+COMMIT

--- a/etc/openvpn/update-route
+++ b/etc/openvpn/update-route
@@ -38,10 +38,10 @@ ip6tables -A FORWARD -i "$vpn_interface" -o "$mesh_interface" -m state --state E
 ip6tables -A FORWARD -i "$mesh_interface" -o "$vpn_interface" -j ACCEPT
 
 # allow DNS queries through the VPN
-ip6tables -A INPUT -i "$vpn_interface" -p tcp -m tcp --dport 53 -m state --state ESTABLISHED -j ACCEPT
-ip6tables -A INPUT -i "$vpn_interface" -p udp -m udp --dport 53 -m state --state ESTABLISHED -j ACCEPT
-iptables -A INPUT -i "$vpn_interface" -p tcp -m tcp --dport 53 -m state --state ESTABLISHED -j ACCEPT
-iptables -A INPUT -i "$vpn_interface" -p udp -m udp --dport 53 -m state --state ESTABLISHED -j ACCEPT
+ip6tables -A INPUT -i "$vpn_interface" -p tcp -m tcp --dport domain -m state --state ESTABLISHED -j ACCEPT
+ip6tables -A INPUT -i "$vpn_interface" -p udp -m udp --dport domain -m state --state ESTABLISHED -j ACCEPT
+iptables -A INPUT -i "$vpn_interface" -p tcp -m tcp --dport domain -m state --state ESTABLISHED -j ACCEPT
+iptables -A INPUT -i "$vpn_interface" -p udp -m udp --dport domain -m state --state ESTABLISHED -j ACCEPT
 
 # resolve NAT64 through the VPN
 iptables -A FORWARD -i nat64 -o "$vpn_interface" -j ACCEPT

--- a/etc/openvpn/update-route
+++ b/etc/openvpn/update-route
@@ -31,33 +31,26 @@ ip rule del table vpn &> /dev/null
 ip route flush table vpn
 ip route add "$vpn_gateway_v4" dev tun0 table vpn
 ip route add default dev tun0 table vpn
-ip rule add dev "nat64" table vpn prio 32565
+ip rule add dev nat64 table vpn prio 32565
 
-# Always accept loopback traffic
-ip6tables -A INPUT -i lo -j ACCEPT
-iptables -A INPUT -i lo -j ACCEPT
-
-# Allow established connections, and those not coming from the outside
-ip6tables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-ip6tables -A INPUT -m state --state NEW ! -i "$vpn_interface" -j ACCEPT
+# forward traffic between freifunk and the VPN (if the connection originated in freifunk)
 ip6tables -A FORWARD -i "$vpn_interface" -o "$mesh_interface" -m state --state ESTABLISHED,RELATED -j ACCEPT
-iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-iptables -A INPUT -m state --state NEW ! -i "$vpn_interface" -j ACCEPT
-iptables -A FORWARD -i "$vpn_interface" -o "$mesh_interface" -m state --state ESTABLISHED,RELATED -j ACCEPT
-
-# Allow outgoing connections from the mesh side.
 ip6tables -A FORWARD -i "$mesh_interface" -o "$vpn_interface" -j ACCEPT
-iptables -A FORWARD -i "$mesh_interface" -o "$vpn_interface" -j ACCEPT
 
-# Masquerade.
+# allow DNS queries through the VPN
+ip6tables -A INPUT -i "$vpn_interface" -p tcp -m tcp --dport 53 -m state --state ESTABLISHED -j ACCEPT
+ip6tables -A INPUT -i "$vpn_interface" -p udp -m udp --dport 53 -m state --state ESTABLISHED -j ACCEPT
+iptables -A INPUT -i "$vpn_interface" -p tcp -m tcp --dport 53 -m state --state ESTABLISHED -j ACCEPT
+iptables -A INPUT -i "$vpn_interface" -p udp -m udp --dport 53 -m state --state ESTABLISHED -j ACCEPT
+
+# resolve NAT64 through the VPN
+iptables -A FORWARD -i nat64 -o "$vpn_interface" -j ACCEPT
+iptables -A FORWARD -i "$vpn_interface" -o nat64 -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# NAT66 all freifunk traffic
 ip6tables --table nat -A POSTROUTING -o "$vpn_interface" -j MASQUERADE
-iptables --table nat -A POSTROUTING -o "$vpn_interface" -j MASQUERADE
 
-# Don't forward from the outside to the inside.
-ip6tables -A FORWARD -i "$vpn_interface" -o "$vpn_interface" -j REJECT
-iptables -A FORWARD -i "$vpn_interface" -o "$vpn_interface" -j REJECT
-
-# Enable routing.
+# Enable routing
 echo 1 > /proc/sys/net/ipv6/conf/default/forwarding
 echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
 echo 1 > /proc/sys/net/ipv4/conf/default/forwarding

--- a/setup_server.sh
+++ b/setup_server.sh
@@ -89,6 +89,14 @@ if [ ! -f /root/scripts/update.sh ]; then
 	fi
 fi
 
+if [ ! -d /etc/iptables ]; then
+	echo "(I) Installing persistent iptables"
+	apt-get install --assume-yes iptables-persistent
+	cp -rf etc/iptables /etc/
+
+	/etc/init.d/netfilter-persistent restart
+fi
+
 if ! is_installed "lighttpd"; then
 	echo "(I) Install lighttpd"
 	apt-get install --assume-yes lighttpd


### PR DESCRIPTION
This also moves some of the rules related to DNS64 to the static iptables
rules. Of course, if someone only calls setup_server, we end up with rules
which mention devices which only exist for gateways. That's not ideal but it
should not be an issue.