### PR TITLE
Alfred non root

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -91,7 +91,7 @@ if ! is_running "alfred"; then
 	chown root.alfred /sys/kernel/debug
 	chmod 750 /sys/kernel/debug
 	# create separate run dir with appropriate access rights because it gets deleted with every reboot
-	mkdir --parents --mode=770 /var/run/alfred/
+	mkdir --parents --mode=750 /var/run/alfred/
 	chown alfred.alfred /var/run/alfred/
 
 	echo "(I) Start alfred."

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -90,6 +90,9 @@ if ! is_running "alfred"; then
 	# set minimum access rights for reading information out of kernel debug interface
 	chown root.alfred /sys/kernel/debug
 	chmod 750 /sys/kernel/debug
+	# create separate run dir with appropriate access rights because it gets deleted with every reboot
+	mkdir --parents --mode=770 /var/run/alfred/
+
 	echo "(I) Start alfred."
         start-stop-daemon --start --quiet --pidfile /var/run/alfred/alfred.pid \
                 --umask 0117 --make-pidfile --chuid alfred --group alfred \

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -92,6 +92,7 @@ if ! is_running "alfred"; then
 	chmod 750 /sys/kernel/debug
 	# create separate run dir with appropriate access rights because it gets deleted with every reboot
 	mkdir --parents --mode=770 /var/run/alfred/
+	chown alfred.alfred /var/run/alfred/
 
 	echo "(I) Start alfred."
         start-stop-daemon --start --quiet --pidfile /var/run/alfred/alfred.pid \

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -87,6 +87,9 @@ if ip -6 addr add "$ip_addr/64" dev bat0 2> /dev/null; then
 fi
 
 if ! is_running "alfred"; then
+	# set minimum access rights for reading information out of kernel debug interfac
+	chown root.alfred /sys/kernel/debug
+	chmod 750 /sys/kernel/debug
 	echo "(I) Start alfred."
         start-stop-daemon --start --quiet --pidfile /var/run/alfred/alfred.pid \
                 --umask 0117 --make-pidfile --chuid alfred --group alfred \

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -87,7 +87,7 @@ if ip -6 addr add "$ip_addr/64" dev bat0 2> /dev/null; then
 fi
 
 if ! is_running "alfred"; then
-	# set minimum access rights for reading information out of kernel debug interfac
+	# set minimum access rights for reading information out of kernel debug interface
 	chown root.alfred /sys/kernel/debug
 	chmod 750 /sys/kernel/debug
 	echo "(I) Start alfred."

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -88,7 +88,10 @@ fi
 
 if ! is_running "alfred"; then
 	echo "(I) Start alfred."
-	start-stop-daemon --start --background --exec `which alfred` -- -i bat0 -m
+        start-stop-daemon --start --quiet --pidfile /var/run/alfred/alfred.pid \
+                --umask 0117 --make-pidfile --chuid alfred --group alfred \
+                --background --exec `which alfred` --oknodo \
+                -- -i bat0 -m -u /var/run/alfred/alfred.sock
 fi
 
 if ! is_running "lighttpd"; then
@@ -99,7 +102,7 @@ fi
 #announce status website via alfred
 {
 	echo -n "{\"link\" : \"http://[$ip_addr]/index.html\", \"label\" : \"Freifunk Gateway $name\"}"
-} | alfred -s 91
+} | alfred -s 91 -u /var/run/alfred/alfred.sock
 
 
 #announce map information via alfred
@@ -129,11 +132,11 @@ fi
 	echo -n '], '
 	echo -n "\"clientcount\" : 0"
 	echo -n '}'
-} | gzip -c - | alfred -s 64
+} | gzip -c - | alfred -s 64 -u /var/run/alfred/alfred.sock
 
 
 #collect all map pieces
-alfred -r 64 > /tmp/maps.txt
+alfred -r 64 -u /var/run/alfred/alfred.sock > /tmp/maps.txt
 
 #create map data
 ./ffmap-backend.py -m /tmp/maps.txt -a ./aliases.json > /var/www/nodes.json

--- a/setup_server.sh
+++ b/setup_server.sh
@@ -176,6 +176,27 @@ fi
 }
 
 {
+	# set capablilities for alfred binary (create sockets and use elevated privs)
+	# got reset by installation of new alfred binary above
+	# (FYI: dropping of privileges is possible since alfred version 2015.0)
+	setcap cap_net_raw+ep `which alfred`
+
+	# create alfred group
+	addgroup --system alfred
+
+	# create separate run dir with appropriate access rights
+	mkdir -p /var/run/alfred/
+	chmod 770 /var/run/alfred/
+
+	echo "(I) Create user alfred for alfred daemon."
+	adduser --system --home /var/run/alfred --shell /bin/false --no-create-home --ingroup alfred --disabled-password alfred
+
+	# root user has to access alfred.sock via update.sh later
+	chown alfred.alfred /var/run/alfred/
+	usermod -aG alfred root
+}
+
+{
 	echo "(I) Install fastd."
 
 	apt-get install --assume-yes git cmake-curses-gui libnacl-dev flex bison libcap-dev pkg-config zip libjson-c-dev
@@ -340,4 +361,6 @@ fi
 
 echo "done"
 
-/root/scripts/update.sh
+# user root got assigned to alfred group, so use new environment here:
+# that is why we start a bash
+bash /root/scripts/update.sh

--- a/setup_server.sh
+++ b/setup_server.sh
@@ -185,8 +185,7 @@ fi
 	addgroup --system alfred
 
 	# create separate run dir with appropriate access rights
-	mkdir -p /var/run/alfred/
-	chmod 770 /var/run/alfred/
+	mkdir --parents --mode=770 /var/run/alfred/
 
 	echo "(I) Create user alfred for alfred daemon."
 	adduser --system --home /var/run/alfred --shell /bin/false --no-create-home --ingroup alfred --disabled-password alfred

--- a/setup_server.sh
+++ b/setup_server.sh
@@ -360,6 +360,6 @@ fi
 
 echo "done"
 
-# user root got assigned to alfred group, so use new environment here:
-# that is why we start a bash
-bash /root/scripts/update.sh
+# user root got assigned to alfred group, so use new environment here.
+# call update script to immediately display correct statistics on server website.
+newgrp alfred && newgrp - && /root/scripts/update.sh

--- a/setup_server.sh
+++ b/setup_server.sh
@@ -362,4 +362,4 @@ echo "done"
 
 # user root got assigned to alfred group, so use new environment here.
 # call update script to immediately display correct statistics on server website.
-newgrp alfred && newgrp - && /root/scripts/update.sh
+newgrp alfred && newgrp && /root/scripts/update.sh

--- a/setup_server.sh
+++ b/setup_server.sh
@@ -185,7 +185,7 @@ fi
 	addgroup --system alfred
 
 	# create separate run dir with appropriate access rights
-	mkdir --parents --mode=770 /var/run/alfred/
+	mkdir --parents --mode=750 /var/run/alfred/
 
 	echo "(I) Create user alfred for alfred daemon."
 	adduser --system --home /var/run/alfred --shell /bin/false --no-create-home --ingroup alfred --disabled-password alfred


### PR DESCRIPTION
Since alfred 2015.0 it is possible to drop root privileges for alfred daemon and run it as a separate user. Since alfred handles unfiltered information of "bat0" interface it should be run with the least privileges possible.
This bunch of patches integrates the necessary changes into the server setup and the update script.
